### PR TITLE
Allow decks to be marked as public. Make Deck color input select.

### DIFF
--- a/src/components/page/Collection.jsx
+++ b/src/components/page/Collection.jsx
@@ -39,6 +39,7 @@ export class _Collection extends React.Component {
 
     // Closure for inner class
     const attemptDeleteDeck = this.attemptDeleteDeck.bind(this);
+    const attemptMarkDeckAsPublic = this.attemptMarkDeckAsPublic.bind(this);
 
     this.DeckComponent = createReactClass({
       getDefaultProps() {
@@ -60,6 +61,10 @@ export class _Collection extends React.Component {
                   params={{ deckId: data.id }}>
               <span className="fa fa-trophy"></span>&nbsp;Take quiz
             </Link>
+            <Button className="btn btn-white btn-xs"
+                    onClick={ () => attemptMarkDeckAsPublic(data) }>
+              <span className="fa fa-users"></span>&nbsp;Make public
+            </Button>
             <Button className="btn btn-danger btn-xs"
                     onClick={ () => attemptDeleteDeck(data.id) }>
               <span className="fa fa-trash-o"></span>&nbsp;Delete
@@ -106,7 +111,17 @@ export class _Collection extends React.Component {
                          },
                          {
                            name: "color",
-                           type: "text",
+                           type: "select",
+                           spec: [
+                             { value: "red", label: "Red" },
+                             { value: "orange", label: "Orange" },
+                             { value: "yellow", label: "Yellow" },
+                             { value: "green", label: "Green" },
+                             { value: "blue", label: "Blue" },
+                             { value: "indigo", label: "Indigo" },
+                             { value: "violet", label: "Violet" },
+                             { value: "black", label: "Black" },
+                           ],
                            label: "Color"
                          }]} />
           </Modal.Body>

--- a/src/components/reusable/Form.jsx
+++ b/src/components/reusable/Form.jsx
@@ -1,6 +1,11 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 
-export class FormInput extends React.Component {
+
+class FormInput extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
   render() {
     const { label, type, placeholder, help } = this.props;
 
@@ -25,6 +30,46 @@ export class FormInput extends React.Component {
   }
 }
 
+
+class FormSelect extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    const { label, spec, help } = this.props;
+
+    return (
+      <div className="form-group">
+        { label ? <label>{ label }</label> : null }
+        <select className="form-control" ref={ input => this.input = input }>
+          { spec.map( (item, i) => {
+              return (
+                <option key={i} value={ item.value }>{ item.label }</option>
+              );
+          }) }
+        </select>
+        { help ? <small className="form-text text-muted">{ help }</small> : null }
+      </div>
+    );
+  }
+
+  val(newVal) {
+    if (newVal !== undefined) {
+      $(this.input).val(newVal);
+    } else {
+      return $(this.input).val();
+    }
+  }
+}
+
+FormSelect.propTypes = {
+  label: PropTypes.string,
+  spec: PropTypes.array,
+  help: PropTypes.string,
+};
+
+
 export default class Form extends React.Component {
   render() {
     return (
@@ -32,3 +77,6 @@ export default class Form extends React.Component {
     );
   }
 }
+
+Form.Input = FormInput;
+Form.Select = FormSelect;

--- a/src/components/reusable/SmartForm.jsx
+++ b/src/components/reusable/SmartForm.jsx
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import React from 'react';
-import Form, { FormInput } from './Form.jsx';
+import Form from './Form.jsx';
 
 export default class SmartForm extends React.Component {
   render() {
@@ -16,10 +16,18 @@ export default class SmartForm extends React.Component {
       let element = null;
 
       switch(item.type) {
+        case 'select':
+          element = (
+            <Form.Select key={ item.name }
+                         spec={ item.spec }
+                         ref={ input => this[item.name + 'Input'] = input } />
+          );
+          break;
+          
         default:
           // The default is a normal text input
           element = (
-            <FormInput { ...item }
+            <Form.Input { ...item }
                        key={ item.name }
                        ref={ input => this[item.name + 'Input'] = input } />
           );


### PR DESCRIPTION
Reintroduce the "mark deck as public" button that was lost in the
previous refactor.

In the deck creation modal, the input for the color attribute is now a
select.

Changed the Form reusable component to use the dot syntax for child
compoenents e.g. Form.Input and Form.Select

Introduce the Form.Select child component of the Form reusable component